### PR TITLE
SSL connections: whatthecommit

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A curated list of awesome console services (reachable via HTTP, HTTPS and other 
 
 ## Messages/texts/fortunes/names generators
 
-* `git commit -m $(curl -s https://whatthecommit.com/index.txt)` — generate random commit message
+* `git commit -m $(curl -sk https://whatthecommit.com/index.txt)` — generate random commit message
 * `curl -H 'Accept: text/plain' foaas.com/cool/:from` — fuck off as a service
 * `curl -s https://uinames.com/api/?region=france\&amount=25 | jq '.[] | .name +" " + .surname'` — generate 25 random french names
 


### PR DESCRIPTION
Perform "insecure" SSL connections on `whatthecommit`



```curl https://whatthecommit.com/index.txt
curl: (60) SSL certificate problem: Invalid certificate chain
More details here: https://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.```