### PR TITLE
Add DNS-based services for IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `curl icanhazip.com`
 * `curl checkip.amazonaws.com`
 
+### DNS
+* `dig @1.1.1.1 whoami.cloudflare ch txt +short` (IPv4)
+* `dig @2606:4700:4700::1111 whoami.cloudflare ch txt -6 +short` (IPv6)
+* `dig @ns1.google.com o-o.myaddr.l.google.com TXT -6 +short` (IPv6)
+* `dig @ns1.google.com o-o.myaddr.l.google.com TXT -4 +short` (IPv4)
+* `dig resolver.dnscrypt.info TXT +short`
+
 ### JSON only
 * `curl httpbin.org/ip`
 * `curl wtfismyip.com/json`


### PR DESCRIPTION
Based on https://community.cloudflare.com/t/can-1-1-1-1-be-used-to-find-out-ones-public-ip-address/14971/8

(Normalized parameter order based on `dig -h`)