### PR TITLE
Multiple minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## IP address
 
-### inline
+### Inline
+
 * `curl l2.io/ip`
 * `curl echoip.de`
 * `curl ifconfig.me`
@@ -44,7 +45,8 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `curl ipv4bot.whatismyipaddress.com`
 * `curl ipcalf.com`
 
-### new line
+### New line
+
 * `curl eth0.me`
 * `curl ipaddr.site`
 * `curl ifconfig.co`
@@ -58,6 +60,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `curl ifconfig.io/ip`
 
 ### DNS
+
 * `dig @1.1.1.1 whoami.cloudflare ch txt +short` (IPv4)
 * `dig @2606:4700:4700::1111 whoami.cloudflare ch txt -6 +short` (IPv6)
 * `dig @ns1.google.com o-o.myaddr.l.google.com TXT -6 +short` (IPv6)
@@ -66,6 +69,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `curl https://dnsjson.com/resolver.dnscrypt.info/TXT.json`
 
 ### JSON only
+
 * `curl httpbin.org/ip`
 * `curl wtfismyip.com/json`
 * `curl -L iphorse.com/json`
@@ -112,33 +116,33 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## Weather
 
-* `curl wttr.in` or `curl wttr.in/Berlin` - the right way to check the weather
+* `curl wttr.in` or `curl wttr.in/Berlin` — the right way to check the weather
 * `finger oslo@graph.no`
 
 ## News
 
-* `curl getnews.tech/world+cup` - fetch the latest news
+* `curl getnews.tech/world+cup` — fetch the latest news
 * `gopher txtn.ws`
 * `ssh redditbox.us` — Reddit in terminal (ssh + text browser)
 
 ## Information boards
 
-* `curl http://frcl.de/gulasch` - Gulaschprogrammiernacht 2019 Fahrplan
+* `curl http://frcl.de/gulasch` — Gulaschprogrammiernacht 2019 Fahrplan
 
 ## Map
 
-* `telnet mapscii.me` - show a zoomable world map
+* `telnet mapscii.me` — show a zoomable world map
 
 ## Money
 
-* `curl rate.sx` - get cryptocurrencies exchange rates
-* `curl moneroj.org` - get Monero exchange rate
-* `curl cmc.rjldev.com` - get coinmarketcap top 100 cryptocurrencies
+* `curl rate.sx` — get cryptocurrencies exchange rates
+* `curl moneroj.org` — get Monero exchange rate
+* `curl cmc.rjldev.com` — get coinmarketcap top 100 cryptocurrencies
 * `telnet ticker.bitcointicker.co 10080` — get BTC/USD exchange rate
 
 ## Documentation
 
-* `curl cheat.sh` - UNIX/Linux commands cheat sheets using curl ([chubin/cheat.sh](https://github.com/chubin/cheat.sh))
+* `curl cheat.sh` — UNIX/Linux commands cheat sheets using curl ([chubin/cheat.sh](https://github.com/chubin/cheat.sh))
 
 ## Dictionaries and translators
 
@@ -172,7 +176,6 @@ Telnet/SSH-based:
 * `telnet milek7.gq` — games: Pong, Break out, Tetris
 * `telnet aardmud.org` — MUD
 * `telnet mud.darkerrealms.org 2000` — MUD
-
 * `telnet telehack.com`
 
 ## Scripts

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `curl ip.tyk.nu`
 * `curl bot.whatismyipaddress.com`
 * `curl curlmyip.net`
+* `curl api.ipify.org`
+* `curl ipv4bot.whatismyipaddress.com`
+* `curl ipcalf.com`
 
 ### new line
 * `curl eth0.me`
@@ -50,6 +53,9 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `curl ipinfo.io/ip`
 * `curl icanhazip.com`
 * `curl checkip.amazonaws.com`
+* `curl smart-ip.net/myip`
+* `curl ip-api.com/line?fields=query`
+* `curl ifconfig.io/ip`
 
 ### DNS
 * `dig @1.1.1.1 whoami.cloudflare ch txt +short` (IPv4)
@@ -62,6 +68,12 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 ### JSON only
 * `curl httpbin.org/ip`
 * `curl wtfismyip.com/json`
+* `curl -L iphorse.com/json`
+* `curl geoplugin.net/json.gp`
+* `curl https://ipapi.co/json`
+* `curl -L jsonip.com`
+* `curl gd.geobytes.com/GetCityDetails`
+* `curl ip.jsontest.com`
 
 ## Geolocation
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,12 @@ Useful scripts, that can be run with just one line of code, but where, still loc
 
 At least on of the clients, that you need to access these services, is installed in almost every UNIX/Linux system.
 
+* [aria2](https://aria2.github.io/)
+* [bitsadmin](https://docs.microsoft.com/windows/win32/bits/)
 * [curl](https://curl.haxx.se/)
 * [httpie](https://httpie.org/)
+* [httrack](https://www.httrack.com/)
+* [powershell](https://microsoft.com/powershell/)
+* [rclone](https://rclone.org/)
 * [wget](https://www.gnu.org/software/wget/)
 * [wget2](https://gitlab.com/gnuwget/wget2)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## URL shortener
 
-* `curl -s http://tinyurl.com/api-create.php?url=<link>`
+* `curl -s tinyurl.com/api-create.php?url=<link>`
 * `curl -F shorten=<link> https://ttm.sh`
 
 ## File Transfer
@@ -150,7 +150,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## Generators
 
-* `git commit -m $(curl -sk https://whatthecommit.com/index.txt)` — generate random commit message
+* `git commit -m $(curl -sk whatthecommit.com/index.txt)` — generate random commit message
 * `curl -H 'Accept: text/plain' foaas.com/cool/:from` — fuck off as a service
 * `curl pseudorandom.name` — generate a pseudo random (American?) name ([treyhunner/pseudorandom.name](https://github.com/treyhunner/pseudorandom.name))
 * `curl -s https://uinames.com/api/?region=france\&amount=25 | jq '.[] | .name +" " + .surname'` — generate 25 random french names

--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 ## URL shortener
 
 * `curl -s http://tinyurl.com/api-create.php?url=http://www.google.com`
+* `curl -F shorten=http://www.google.com https://ttm.sh`
 
 ## File Transfer
 
 * `curl --upload-file <file> transfer.sh/<filename>`
 * `curl --upload-file <file> filepush.co/upload/<filename>`
+* `curl -F file=@<file> https://ttm.sh`
 
 ## Browser
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## Dictionaries and translators
 
-* `curl 'dict://dict.org/d:command line'`
+* `curl 'dict.org/d:command line'`
 
 ## Generators
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `echo "Hello world!" | curl -F file=@- 0x0.st`
 * `echo "Hello world!" | curl -F 'clbin=<-' https://clbin.com`
 * `echo "Hello world!" | nc termbin.com 9999`
+* `echo "Hello world!" | curl -F 'sprunge=<-' sprunge.us`
 
 ## URL shortener
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## URL shortener
 
-* `curl -s http://tinyurl.com/api-create.php?url=http://www.google.com`
-* `curl -F shorten=http://www.google.com https://ttm.sh`
+* `curl -s http://tinyurl.com/api-create.php?url=<link>`
+* `curl -F shorten=<link> https://ttm.sh`
 
 ## File Transfer
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Useful scripts, that can be run with just one line of code, but where, still loc
 
 At least on of the clients, that you need to access these services, is installed in almost every UNIX/Linux system.
 
-* [curl](https://github.com/curl/curl)
-* [httpie](https://github.com/jakubroztocil/httpie) — modern command line HTTP client
+* [curl](https://curl.haxx.se/)
+* [httpie](https://httpie.org/)
 * [wget](https://www.gnu.org/software/wget/)
 * [wget2](https://gitlab.com/gnuwget/wget2)


### PR DESCRIPTION
- d783b8c Replaced the curl and httpie GitHub links with their respective official websites
- 969cb20 Added aria2, bitsadmin, httrack, powershell and rclone to the clients list
- 853a43c Added 12 IP services. Turns out there are a lot of these :)
- 80f4a57, 1e42c8e Added the ttm.sh uploader/URL shortener and sprunge pastebin
- aac2bec Replaced the Google link with a placeholder. Since the file transfer services use <file> in place of the actual file, I thought it'd make sense to use <link> here instead of google.com
- 279c34d Added missing newlines after some headings and replaced instances of "-" with the in the README more widely used "—"
- 0b44e13, a8eea64 Stripped the protocol where it isn't required