### PR TITLE
Add ipaddress.sh to Inline

### DIFF
--- a/structured.yaml
+++ b/structured.yaml
@@ -7,6 +7,8 @@ by_category:
         tags: [curl, plain]
       ifconfig.me:
         tags: [curl, plain]
+      ipaddress.sh:
+        tags: [curl, plain]
       ipecho.net:
         tags: [curl, plain]
       ident.me:


### PR DESCRIPTION
I am in no way affiliated with `ipaddress.sh` and have no idea as to who the organization is that is behind it.  I don't even know *when* or *where* I found out about the site, but since my external IP is something that I so rarely need to know, this sites name is one I immediately recall.