### PR TITLE
README: Generators: Add missing quote flag in commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## Generators
 
-* `git commit -m $(curl -sk whatthecommit.com/index.txt)` — generate random commit message
+* `git commit -m "$(curl -sk whatthecommit.com/index.txt)"` —  generate random commit message
 * `curl -H 'Accept: text/plain' foaas.com/cool/:from` — fuck off as a service
 * `curl pseudorandom.name` — generate a pseudo random (American?) name ([treyhunner/pseudorandom.name](https://github.com/treyhunner/pseudorandom.name))
 * `curl -s https://uinames.com/api/?region=france\&amount=25 | jq '.[] | .name +" " + .surname'` — generate 25 random french names


### PR DESCRIPTION
- The folllowing line of command does not work, It gives pathspec error. This is happening becaue the command we are executing to commit our messages i.e $(curl -sk whatthecommit.com/index.txt) is not under quotes.

- The commit message should be under quotes because whattcommit.com/index.txt generates more then a word or we can say a commit in a sentance, and to add a sentance in our commits we need to quote it .

--> Adding quotes fixes this issue.