### PR TITLE
Add ipaddy.net

### DIFF
--- a/.github/action-test/entrypoint.sh
+++ b/.github/action-test/entrypoint.sh
@@ -112,6 +112,7 @@ test_curl 200 bot.whatismyipaddress.com
 test_curl 200 curlmyip.net
 
 echo -e "### new line"
+test_curl 200 ipaddy.net
 test_curl 200 eth0.me
 test_curl 200 ipaddr.site
 test_curl 200 ifconfig.co

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ### New line
 
+* `curl ipaddy.net`
 * `curl eth0.me`
 * `curl ipaddr.site`
 * `curl ifconfig.co`

--- a/structured.yaml
+++ b/structured.yaml
@@ -23,6 +23,8 @@ by_category:
         tags: [curl, plain]
       bot.whatismyipaddress.com:
         tags: [curl, plain]
+      ipaddy.net:
+        tags: [curl, plain, newline]
       eth0.me:
         tags: [curl, plain, newline]
       ipaddr.site:


### PR DESCRIPTION
Added `ipaddy.net` which is a personal project that I maintain. More info can be found at <https://use.ipaddy.net/>