### PR TITLE
A curl tool that shows Covid-19 statistics for the visitor's Country.

### DIFF
--- a/.github/action-test/entrypoint.sh
+++ b/.github/action-test/entrypoint.sh
@@ -182,6 +182,7 @@ test_curl 200 wttr.in/semarang
 # test_finger "Meteogram for norway" oslo@graph.no
 
 echo -e "## News"
+test_curl 200 snf-878293.vm.okeanos.grnet.gr
 test_curl 200 getnews.tech/world+cup
 # alpine doesnt have gopher
 # * `gopher txtn.ws`

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## News
 
+* `curl snf-878293.vm.okeanos.grnet.gr` - Covid-19 statistics for your country
 * `curl getnews.tech/world+cup` — fetch the latest news
 * `gopher://gopher.leveck.us:70` - news aggregator
 * `gopher://gopherddit.com:70`  - reddit

--- a/structured.yaml
+++ b/structured.yaml
@@ -88,6 +88,9 @@ by_category:
       graph.no:
         tags: [finger]
   - news:
+      snf-878293.vm.okeanos.grnet.gr:
+        tags: [curl]
+        repository: https://github.com/catman85/TermApp-Node-Typesript-Docker-Express
       getnews.tech:
         tags: [curl]
       txtn.ws:


### PR DESCRIPTION
Simply type  `curl snf-878293.vm.okeanos.grnet.gr`

Repo: https://github.com/catman85/TermApp-Node-Typesript-Docker-Express

Originally inspired by wttr.in which I use daily.