### PR TITLE
Add service to view stock information and market summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * :no_entry_sign: `curl cmc.rjldev.com` — get coinmarketcap top 100 cryptocurrencies
 * `nc ticker.bitcointicker.co 10080` — get BTC/USD exchange rate (also works with telnet)
 * `curl stonks.icu/amd/msft` get stock visualizer and tracker
+* `curl terminal-stocks.herokuapp.com/GOOG` - get stocks prices and information
 
 ## Documentation
 


### PR DESCRIPTION
Added service to fetch the stock price information right from your terminal.
**Current Price:**
![Screenshot_Current](https://user-images.githubusercontent.com/35127382/103422822-587c8f80-4bc9-11eb-9a5a-e203b7338a8b.png)

**Historical Price:**
![Screenshot_Historical](https://user-images.githubusercontent.com/35127382/103422842-6df1b980-4bc9-11eb-953b-5916faaf5058.png)

**Market Summary:**
![Screenshot from 2020-12-31 05-10-52](https://user-images.githubusercontent.com/35127382/103422849-7ba73f00-4bc9-11eb-8186-e147a0abbc62.png)


