### PR TITLE
Add cointop

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `nc ticker.bitcointicker.co 10080` — get BTC/USD exchange rate (also works with telnet)
 * `curl stonks.icu/amd/msft` get stock visualizer and tracker
 * `curl terminal-stocks.herokuapp.com/GOOG` - get stocks prices and information
+* `ssh cointop.sh` - cryptocurrency tracking TUI ([source](https://github.com/miguelmota/cointop))
 
 ## Documentation
 


### PR DESCRIPTION
Hi Igor,

This PR adds [cointop](github.com/miguelmota/cointop) which can be accessed via SSH `ssh cointop.sh`. Cointop is an interactive terminal UI for tracking cryptocurrencies.

_Thanks for maintaining this awesome list!_