### PR TITLE
Add shorta.link to URL Shorteners

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * :no_entry_sign: `curl -F shorten=<link> https://ttm.sh`
 * `curl https://is.gd/create.php?format=simple&url=<link>`
 * `curl -F shorten=<link> https://0x0.st`
+* `curl -F url=<link> https://shorta.link`
 
 ## File Transfer
 


### PR DESCRIPTION
I have developed a new URL Shortener that is cURL friendly and I think it can make sense to be in this awesome list.

For more information you can see the URL Shortener code in my repo: https://github.com/piraces/shorta.link

A frontend is available in: https://go.shorta.link/

Thanks!