### PR TITLE
ping.gg moved to ping.gl

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 
 ## Monitoring
 
-* `curl ping.gg`
+* `curl ping.gl`
 
 ## Weather
 


### PR DESCRIPTION
ping.gg has moved to ping.gl. This fixes #84 