### PR TITLE
urlecho.appspot.com and urlreq.appspot.com not responding

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `curl -s "https://decapi.me/twitter/latest?name=NPR"` - last tweet from indicated account
 * `curl -s "https://decapi.me/twitch/uptime?channel=IGN"` - check if indicated twitch channel is online
 * `curl -s "https://httpbin.org/delay/4"` - HTTP request and response Service (e.g. send response after 4 seconds)
-* `curl -s "https://urlecho.appspot.com/echo?body=Hello+World"` - HTTP response defined in the request parameters
-* `curl -s "https://urlreq.appspot.com/req?method=GET&url=https://l2.io/ip"` - HTTP proxy makes new requests based on input parameters
+* :no_entry_sign: `curl -s "https://urlecho.appspot.com/echo?body=Hello+World"` - HTTP response defined in the request parameters
+* :no_entry_sign: `curl -s "https://urlreq.appspot.com/req?method=GET&url=https://l2.io/ip"` - HTTP proxy makes new requests based on input parameters
 * `curl -s "https://api.hackertarget.com/nmap/?q=93.184.216.34"` - TCP port scan using NMAP
 * `curl -s "https://api.hackertarget.com/pagelinks/?q=msn.com"` - Extract all links from a page
 * `curl -s "https://api.hackertarget.com/whois/?q=google.com"` - Whois lookup


### PR DESCRIPTION
I am consistently getting a service response/state of 500 for these services

```
curl -s "https://urlecho.appspot.com/echo?body=Hello+World"

<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>500 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered an error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
```

```
curl -s "https://urlreq.appspot.com/req?method=GET&url=https://l2.io/ip"

<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>500 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered an error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
```