### PR TITLE
Add PixelDrain to file transfer services

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Structured data of the list (kept in sync) is in [structured.yaml](structured.ya
 * `nc oshi.at 7777 < <file>` or `curl https://oshi.at -F f=@<file>`
 * `curl -F file=@<file> https://0x0.st`
 * `curl -F file=@<file> https://api.anonfile.com/upload`
+* `curl -T <file> https://pixeldrain.com/api/file/`
 
 ## Browser
 


### PR DESCRIPTION
I have added a new file hosting service, PixelDrain, to the list of file transfer services in the README.md. PixelDrain offers a convenient and user-friendly platform for uploading and sharing files, making it a valuable addition to the existing collection of services. This addition aims to provide users with more options for file hosting and sharing, enhancing the overall utility of the list.